### PR TITLE
Percentage turnout of voters on the proposal page

### DIFF
--- a/views/proposal.tmpl
+++ b/views/proposal.tmpl
@@ -80,7 +80,7 @@
                   <div class="col-auto d-flex flex-column justify-content-between pl-3">
                     <span class="fs17 lh1em">
                       <span class="fs22 medium-sans">{{printf "%.1f" (f32x100 $metadata.Approval)}}%</span>
-                      approval of {{intComma $metadata.VoteCount}} votes
+                      approval of {{intComma $metadata.VoteCount}} votes ({{printf "%.0f" (percentage $metadata.VoteCount .NumOfEligibleVotes)}}% turnout)
                     </span>
                     {{if $metadata.QuorumAchieved}}
                       <div class="d-flex align-items-center"><span class="fs20 dcricon-affirm mr-2"></span>


### PR DESCRIPTION
Fix for [#1671](https://github.com/decred/dcrdata/issues/1671)

Added voter turnout (% of eligible tickets that voted) on the individual [proposal](https://explorer.planetdecred.org/proposal/decred-europe-marketing-and-events-proposal) pages

![image](https://user-images.githubusercontent.com/35831554/75386719-394f0a80-58f3-11ea-99fe-738d3416f2dc.png)